### PR TITLE
add: GitHubApi interface

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/GitHubApi.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/data/remote/GitHubApi.kt
@@ -1,0 +1,11 @@
+package jp.co.yumemi.android.code_check.data.remote
+
+import retrofit2.http.GET
+import retrofit2.http.Headers
+import retrofit2.http.Query
+
+interface GitHubApi {
+    @Headers("application/vnd.github+json")
+    @GET("search/repositories")
+    suspend fun searchRepositories(@Query("q") query: String): SearchRepositoriesResultDto
+}


### PR DESCRIPTION
### この PR が解決する内容
[APIリファレンス](https://docs.github.com/ja/rest/search?apiVersion=2022-11-28#search-repositories)をもとに、検索時の結果を返す処理のinterfaceを定義します。

### この PR が解決しない内容
APIから結果を得る実処理

### 確認方法
DTOをもとにインターフェースを設計していること
